### PR TITLE
Return error on invalid mnemonics

### DIFF
--- a/deployer/tf_plugin_client.go
+++ b/deployer/tf_plugin_client.go
@@ -113,7 +113,7 @@ func NewTFPluginClient(
 	tfPluginClient := TFPluginClient{}
 
 	if valid := validateMnemonics(mnemonics); !valid {
-		return TFPluginClient{}, errors.Wrapf(err, "mnemonics %s is invalid", mnemonics)
+		return TFPluginClient{}, fmt.Errorf("mnemonics %s is invalid", mnemonics)
 	}
 	tfPluginClient.mnemonics = mnemonics
 


### PR DESCRIPTION
### Description

Remove `errors.Wrapf` because err is nil so returned error was nil too
