### PR TITLE
Modify `LoadK8sFromGrid` to use only node ids

### DIFF
--- a/deployer/state.go
+++ b/deployer/state.go
@@ -138,7 +138,7 @@ func (st *State) LoadK8sFromGrid(nodeIDs []uint32, deploymentName string) (workl
 	for _, nodeID := range nodeIDs {
 		_, deployment, err := st.GetWorkloadInDeployment(nodeID, "", deploymentName)
 		if err != nil {
-			return workloads.K8sCluster{}, errors.Wrapf(err, "could not get workload %s", deploymentName)
+			return workloads.K8sCluster{}, errors.Wrapf(err, "could not get deployment %s", deploymentName)
 		}
 		clusterDeployments[nodeID] = deployment
 		nodeDeploymentID[nodeID] = deployment.ContractID

--- a/deployer/state.go
+++ b/deployer/state.go
@@ -131,59 +131,72 @@ func (st *State) LoadVMFromGrid(nodeID uint32, name string, deploymentName strin
 }
 
 // LoadK8sFromGrid loads k8s from grid
-func (st *State) LoadK8sFromGrid(masterNode map[uint32]string, workerNodes map[uint32][]string, deploymentName string) (workloads.K8sCluster, error) {
-	cluster := workloads.K8sCluster{}
+func (st *State) LoadK8sFromGrid(nodeIDs []uint32, deploymentName string) (workloads.K8sCluster, error) {
 
+	clusterDeployments := make(map[uint32]gridtypes.Deployment)
 	nodeDeploymentID := map[uint32]uint64{}
-	for nodeID, name := range masterNode {
-		wl, dl, err := st.GetWorkloadInDeployment(nodeID, name, deploymentName)
+	for _, nodeID := range nodeIDs {
+		_, deployment, err := st.GetWorkloadInDeployment(nodeID, "", deploymentName)
 		if err != nil {
-			return workloads.K8sCluster{}, errors.Wrapf(err, "could not get workload %s", name)
+			return workloads.K8sCluster{}, errors.Wrapf(err, "could not get workload %s", deploymentName)
 		}
-
-		workloadDiskSize, workloadComputedIP, workloadComputedIP6, err := st.computeK8sDeploymentResources(nodeID, dl)
-		if err != nil {
-			return workloads.K8sCluster{}, errors.Wrapf(err, "could not compute master %s, resources", name)
-		}
-
-		master, err := workloads.NewK8sNodeFromWorkload(wl, nodeID, workloadDiskSize[name], workloadComputedIP[name], workloadComputedIP6[name])
-		if err != nil {
-			return workloads.K8sCluster{}, errors.Wrapf(err, "could not generate master data for %s", name)
-		}
-
-		cluster.Master = &master
-		nodeDeploymentID[nodeID] = dl.ContractID
-
-		deploymentData, err := workloads.ParseDeploymentData(dl.Metadata)
-		if err != nil {
-			return workloads.K8sCluster{}, errors.Wrapf(err, "could not generate master deployment metadata for %s", name)
-		}
-		cluster.SolutionType = deploymentData.ProjectName
+		clusterDeployments[nodeID] = deployment
+		nodeDeploymentID[nodeID] = deployment.ContractID
 	}
 
-	for nodeID, workerNames := range workerNodes {
-		for _, name := range workerNames {
-			wl, dl, err := st.GetWorkloadInDeployment(nodeID, name, deploymentName)
+	cluster := workloads.K8sCluster{}
+
+	for nodeID, deployment := range clusterDeployments {
+		for _, workload := range deployment.Workloads {
+			if workload.Type != zos.ZMachineType {
+				continue
+			}
+			workloadDiskSize, workloadComputedIP, workloadComputedIP6, err := st.computeK8sDeploymentResources(nodeID, deployment)
 			if err != nil {
-				return workloads.K8sCluster{}, errors.Wrapf(err, "could not get workload %s", name)
+				return workloads.K8sCluster{}, errors.Wrapf(err, "could not compute node %s, resources", workload.Name)
 			}
 
-			workloadDiskSize, workloadComputedIP, workloadComputedIP6, err := st.computeK8sDeploymentResources(nodeID, dl)
+			node, err := workloads.NewK8sNodeFromWorkload(workload, nodeID, workloadDiskSize[workload.Name.String()], workloadComputedIP[workload.Name.String()], workloadComputedIP6[workload.Name.String()])
 			if err != nil {
-				return workloads.K8sCluster{}, errors.Wrapf(err, "could not compute worker %s, resources", name)
+				return workloads.K8sCluster{}, errors.Wrapf(err, "could not generate node data for %s", workload.Name)
 			}
 
-			worker, err := workloads.NewK8sNodeFromWorkload(wl, nodeID, workloadDiskSize[name], workloadComputedIP[name], workloadComputedIP6[name])
+			isMaster, err := isMasterNode(workload)
 			if err != nil {
-				return workloads.K8sCluster{}, errors.Wrapf(err, "could not generate worker data for %s", name)
+				return workloads.K8sCluster{}, err
 			}
-
-			cluster.Workers = append(cluster.Workers, worker)
-			nodeDeploymentID[nodeID] = dl.ContractID
+			if isMaster {
+				cluster.Master = &node
+				deploymentData, err := workloads.ParseDeploymentData(deployment.Metadata)
+				if err != nil {
+					return workloads.K8sCluster{}, errors.Wrapf(err, "could not generate node deployment metadata for %s", workload.Name)
+				}
+				cluster.SolutionType = deploymentData.ProjectName
+				continue
+			}
+			cluster.Workers = append(cluster.Workers, node)
 		}
+	}
+	if cluster.Master == nil {
+		return workloads.K8sCluster{}, fmt.Errorf("failed to get master node for k8s cluster %s", deploymentName)
 	}
 	cluster.NodeDeploymentID = nodeDeploymentID
 	return cluster, nil
+}
+
+func isMasterNode(workload gridtypes.Workload) (bool, error) {
+	dataI, err := workload.WorkloadData()
+	if err != nil {
+		return false, errors.Wrapf(err, "could not get workload %s data", workload.Name)
+	}
+	data, ok := dataI.(*zos.ZMachine)
+	if !ok {
+		return false, errors.Wrapf(err, "could not create vm workload from data %v", dataI)
+	}
+	if data.Env["K3S_URL"] == "" {
+		return true, nil
+	}
+	return false, nil
 }
 
 func (st *State) computeK8sDeploymentResources(nodeID uint32, dl gridtypes.Deployment) (

--- a/deployer/state_test.go
+++ b/deployer/state_test.go
@@ -287,7 +287,7 @@ func TestLoadK8sFromGrid(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		state := SetupLoaderTests(t, []gridtypes.Workload{k8sWorkload})
 
-		got, err := state.LoadK8sFromGrid(map[uint32]string{1: "test"}, map[uint32][]string{}, deploymentName)
+		got, err := state.LoadK8sFromGrid([]uint32{1}, deploymentName)
 		assert.NoError(t, err)
 		assert.Equal(t, cluster, got)
 	})
@@ -298,7 +298,7 @@ func TestLoadK8sFromGrid(t *testing.T) {
 
 		state := SetupLoaderTests(t, []gridtypes.Workload{k8sWorkloadCp})
 
-		_, err := state.LoadK8sFromGrid(map[uint32]string{1: "test"}, map[uint32][]string{}, deploymentName)
+		_, err := state.LoadK8sFromGrid([]uint32{1}, deploymentName)
 		assert.Error(t, err)
 	})
 
@@ -311,7 +311,7 @@ func TestLoadK8sFromGrid(t *testing.T) {
 
 		state := SetupLoaderTests(t, []gridtypes.Workload{k8sWorkloadCp})
 
-		_, err := state.LoadK8sFromGrid(map[uint32]string{1: "test"}, map[uint32][]string{}, deploymentName)
+		_, err := state.LoadK8sFromGrid([]uint32{1}, deploymentName)
 		assert.Error(t, err)
 	})
 }

--- a/deployer/tf_plugin_client_workloads.go
+++ b/deployer/tf_plugin_client_workloads.go
@@ -70,17 +70,12 @@ func (t *TFPluginClient) DeployKubernetesCluster(master workloads.K8sNode, worke
 	if err != nil {
 		return workloads.K8sCluster{}, errors.Wrap(err, "failed to deploy kubernetes cluster")
 	}
-	var workersNames []string
+	nodeIDs := []uint32{master.Node}
 	for _, worker := range workers {
-		workersNames = append(workersNames, worker.Name)
-	}
-	workersNodes := make(map[uint32][]string)
-	if len(workersNames) > 0 {
-		workersNodes[workers[0].Node] = workersNames
+		nodeIDs = append(nodeIDs, worker.Node)
 	}
 	return t.State.LoadK8sFromGrid(
-		map[uint32]string{master.Node: master.Name},
-		workersNodes,
+		nodeIDs,
 		master.Name,
 	)
 }

--- a/integration_tests/k8s_test.go
+++ b/integration_tests/k8s_test.go
@@ -130,10 +130,7 @@ func TestK8sDeployment(t *testing.T) {
 	err = tfPluginClient.K8sDeployer.Deploy(ctx, &k8sCluster)
 	assert.NoError(t, err)
 
-	masterMap := map[uint32]string{master.Node: master.Name}
-	workerMap := map[uint32][]string{workerNodeData1.Node: {workerNodeData1.Name, workerNodeData2.Name}}
-
-	result, err := tfPluginClient.State.LoadK8sFromGrid(masterMap, workerMap, k8sCluster.Master.Name)
+	result, err := tfPluginClient.State.LoadK8sFromGrid([]uint32{masterNodeID, workerNodeID}, k8sCluster.Master.Name)
 	assert.NoError(t, err)
 
 	// check workers count
@@ -157,6 +154,6 @@ func TestK8sDeployment(t *testing.T) {
 	err = tfPluginClient.NetworkDeployer.Cancel(ctx, &network)
 	assert.NoError(t, err)
 
-	_, err = tfPluginClient.State.LoadK8sFromGrid(masterMap, workerMap, k8sCluster.Master.Name)
+	_, err = tfPluginClient.State.LoadK8sFromGrid([]uint32{masterNodeID, workerNodeID}, k8sCluster.Master.Name)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
### Description

Modify `LoadK8sFromGrid` to use only node ids

### Related Issues

- https://github.com/threefoldtech/grid3_client_go/issues/164
